### PR TITLE
Update .gitignore to exclude dist directory and modify build commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ package-lock
 /coverage
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
changed /build to /dist in .gitignore to ensure that the dist directory, which contains the build artifacts, will be ignored by Git. This is the standard practice, as these files are generated from source and should not be tracked or stored in your repository.